### PR TITLE
Fix misnamed references to "issues" link

### DIFF
--- a/source/en/1.1.0/index.html.haml
+++ b/source/en/1.1.0/index.html.haml
@@ -182,7 +182,7 @@ version: 1.1.0
 
   %aside
     There’s more. Help me collect these antipatterns by
-    = link_to "opening an issue", data.links.issue
+    = link_to "opening an issue", data.links.issues
     or a pull request.
 
 .frequently-asked-questions
@@ -207,7 +207,7 @@ version: 1.1.0
 
   %p
     Healthy criticism, discussion and suggestions for improvements
-    = link_to "are welcome.", data.links.issue
+    = link_to "are welcome.", data.links.issues
 
 
   %h4#filename


### PR DESCRIPTION
The "issues" link in data/links.json is plural, not singular; https://github.com/olivierlacan/keep-a-changelog/blob/823f4ce1e02ad4b40625c31f46895e28b03d967e/data/links.json#L4